### PR TITLE
NOJIRA - Fix issue with missing dependency.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ lazy val playJsonTests = project in file("playJsonTests") settings(common: _*) s
   name := "play-json-tests",
 
   libraryDependencies ++= Seq(
-    "com.rallyhealth" %% "scalacheck-ops" % "1.0.0",
+    "com.rallyhealth" %% "scalacheck-ops" % "1.2.0",
     "com.typesafe.play" %% "play-json" % playJsonVersion,
     "org.scalacheck" %% "scalacheck" % "1.12.5",
     "org.scalatest" %% "scalatest" % "2.2.6"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 
 resolvers += Resolver.url("Rally Plugin Releases", url("https://artifacts.werally.in/artifactory/ivy-plugins-release"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.rallyhealth" %% "rally-versioning" % "latest.integration") // must appear before rally-sbt-plugin which depends on version.
+addSbtPlugin("com.rallyhealth" %% "rally-versioning" % "latest.release") // must appear before rally-sbt-plugin which depends on version.
  
 addSbtPlugin("com.rallyhealth" %% "rally-sbt-plugin" % "0.2.0")
 


### PR DESCRIPTION
@jtsmith0107 @chrissalij-r @vodopis 

I think I figured out why this was having an issue. The scalacheck-ops version 1.1.0 was not released properly. It took me a couple tries, so it was finally released as 1.1.3. This should fix the issue.

I didn't make the PR to the community version, because this 1.1.3 release is only internal to Rally. Also, scalacheck will be updated on the next version in the community side, so it can be resolved then.