### PR TITLE
Assimilate 1.2.1 into rally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ lazy val commonRootSettings = Seq(
 
 commonRootSettings
 
+val playJsonVersion = "2.3.10"
+
 lazy val common = commonRootSettings ++ Seq(
 
   scalacOptions := {
@@ -45,7 +47,7 @@ lazy val playJsonOps = project in file("playJsonOps") settings(common: _*) setti
   name := "play-json-ops",
 
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-json" % "2.3.7"
+    "com.typesafe.play" %% "play-json" % playJsonVersion
   )
 
 ) dependsOn (
@@ -57,10 +59,10 @@ lazy val playJsonTests = project in file("playJsonTests") settings(common: _*) s
   name := "play-json-tests",
 
   libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-json" % "2.3.7",
-    "org.scalacheck" %% "scalacheck" % "1.12.2",
-    "org.scalatest" %% "scalatest" % "2.2.4",
-    "com.rallyhealth" %% "scalacheck-ops" % "1.1.0"
+    "com.rallyhealth" %% "scalacheck-ops" % "1.0.0",
+    "com.typesafe.play" %% "play-json" % playJsonVersion,
+    "org.scalacheck" %% "scalacheck" % "1.12.5",
+    "org.scalatest" %% "scalatest" % "2.2.6"
   )
 )
 

--- a/playJsonOps/src/main/scala/play/api/libs/json/ops/OFormatOps.scala
+++ b/playJsonOps/src/main/scala/play/api/libs/json/ops/OFormatOps.scala
@@ -2,7 +2,7 @@ package play.api.libs.json.ops
 
 import play.api.libs.json._
 
-object OFormatOps {
+object OFormatOps extends OFormatPure {
 
   def of[T: OFormat]: OFormat[T] = implicitly
 }


### PR DESCRIPTION
@chrissalij-r @jtsmith0107 @macmacbr @mingy711 

I dropped the scalacheck version back down to 1.0.0 because RCU is having trouble with 1.1.3. I am still unable to figure out the source of the issue. Thankfully with our fork, we can just downgrade the rally fork :)