### PR TITLE
Switched from me.jeffmay to com.rallyhealth org for scalacheck-ops

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
       case `scalatest2Version` => ""
       case `scalatest3Version` => "_1-13"
     }
-    "me.jeffmay" %% s"scalacheck-ops$suffix" % scalacheckOpsVersion
+    "com.rallyhealth" %% s"scalacheck-ops$suffix" % scalacheckOpsVersion
   }
 
   def scalatest(scalatestVersion: String): ModuleID = {


### PR DESCRIPTION
@karkum-rally @virdis 

@AudaxHealthInc/coreverge-pillar 

This pulls the change into the 1.6.x branch, so that we don't have to introduce breaking changes from the v2 branch to get this fix.